### PR TITLE
Updated Events Team Section of "About" Page

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6699,7 +6699,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/aos/-/aos-2.3.4.tgz",
       "integrity": "sha512-zh/ahtR2yME4I51z8IttIt4lC1Nw0ktsFtmeDzID1m9naJnWXhCoARaCgNOGXb5CLy3zm+wqmRAEgMYB5E2HUw==",
-      "license": "MIT",
       "dependencies": {
         "classlist-polyfill": "^1.0.3",
         "lodash.debounce": "^4.0.6",

--- a/website/src/components/About.js
+++ b/website/src/components/About.js
@@ -34,7 +34,7 @@ import Ananya from "../assets/images/headshots/Ananya.jpg";
 import Alyssa from "../assets/images/headshots/alyssa.JPG"; // No longer in club
 //events
 import Tracy from "../assets/images/headshots/Tracy.jpg"; // No longer in club
-import Rounika from "../assets/images/headshots/Rounika.jpg";
+//import Rounika from "../assets/images/headshots/Rounika.jpg";
 import Vivian from "../assets/images/headshots/Vivian.jpg";
 import Arlen from "../assets/images/headshots/Arlen.jpg";
 
@@ -427,9 +427,9 @@ const About = () => {
 
           {/* EVENTS TEAM HEADSHOTS */}
           {openSections.events && (
-            <div className='grid grid-cols-2 md:grid-cols-2 lg:grid-cols-4 justify-items-center gap-8'>
+            <div className='grid grid-cols-1 md:grid-cols-3 lg:grid-cols-3 justify-items-center gap-8'>
               <Person name='Vivian Webster' title='Events Director' image={Vivian} />
-              <Person name='Rounika Saxena' title='Events Coordinator' image={Rounika} />
+              {/* <Person name='Rounika Saxena' title='Events Coordinator' image={Rounika} /> */}
               <Person name='Ethan Xu' title='Events Coordinator' image={temp} />
               <Person name='Leif Hill' title='Events Outreach' image={temp} />
             </div>


### PR DESCRIPTION
Did the following:
- Based on what was discussed at the November 13th executive meeting, removed Rounika from the Events Team section of the "About" page, and readjusted the Events Team section to work with responsiveness.
- Installed the `aos` library locally, which is why there is the change to the `package-lock.json` file in this pull request.