### PR TITLE
404 Page Reload Fix

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
As mentioned in the Discord, when reloading a page on the website it takes the user to Vercel's built-in 404 page. Additionally, the website doesn't use the custom 404 page, and instead uses Vercel's built-in 404 page.

To resolve this, a `vercel.json` file was added to (hopefully) fix the routing. I will see if this fixes the issue on the Vercel preview environment. If it fixes it there, then this PR can likely be merged. Otherwise, I will look into other solutions to this issue.